### PR TITLE
Escape `-` in PR title regex

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -21,7 +21,8 @@ jobs:
       - uses: morrisoncole/pr-lint-action@327d08270eeda69f390c2073935506556987b9a1 # v1.7.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          title-regex: "^[A-Z].*[^.?!,-;:]$"
+          # https://regex101.com/r/I6oK5v/1
+          title-regex: "^[A-Z].*[^.?!,\-;:]$"
           on-failed-regex-fail-action: true
           on-failed-regex-create-review: false
           on-failed-regex-request-changes: false


### PR DESCRIPTION
In a character class, `,-;` is a range expression. It matches `,`, `;`, and all characters between (all digits). So this workflow does not permit the PR title "Release v1.12.0".

This escapes `-`, so that the character class matches just the characters `.?!,-;:`, which I think was the intention.

To reproduce: https://regex101.com/r/I6oK5v/1