### PR TITLE
Disallow ending first word in PR title in "s"

### DIFF
--- a/.github/workflows/pr-title.yaml
+++ b/.github/workflows/pr-title.yaml
@@ -21,10 +21,10 @@ jobs:
       - uses: morrisoncole/pr-lint-action@327d08270eeda69f390c2073935506556987b9a1 # v1.7.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          # https://regex101.com/r/I6oK5v/1
-          title-regex: "^[A-Z].*[^.?!,\\-;:]$"
+          # https://regex101.com/r/pa7WU5/2
+          title-regex: "^[A-Z]\\w+[^s] .*[^.?!,\\-;:]$"
           on-failed-regex-fail-action: true
           on-failed-regex-create-review: false
           on-failed-regex-request-changes: false
-          on-failed-regex-comment: "PR titles must start with a capital letter and not end with punctuation."
+          on-failed-regex-comment: "PR titles must start with a capital letter, not end the first word in 's' (ideally the imperative, present tense!), and not end with punctuation."
           on-succeeded-regex-dismiss-review-comment: "Thanks for helping keep our PR titles consistent!"


### PR DESCRIPTION
This just further restricts our PR titles, which ideally would all be the imperative, present tense (like a [good Git commit][1]). While we can't really do that in regex, we can do a little better.

One minor side-effect of this change is that because we have a literal " " character in the regex, we're now requiring multiple words in a PR - I doubt there's a downside to this, though.

The regex is now basically:

* One capitalized letter
* Any number of word characters
* End first word not with "s"
* Space character
* Any characters
* Not end in punctuation

From tpope:

> Write your commit message in the imperative: "Fix bug" and not "Fixed bug" or "Fixes bug."  This convention matches up with commit messages generated by commands like git merge and git revert.

[1]: https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
