### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.md
+++ b/.github/workflows/dependabot-automerge.md
@@ -1,0 +1,125 @@
+# Dependabot Auto-Merge
+
+This GitHub workflow automatically merges Dependabot PRs for patch and minor updates that pass CI.
+
+## Usage
+
+Copy one of these into `.github/workflows/dependabot-automerge.yaml`.
+
+For repositories **with** required status checks:
+
+```yaml
+name: dependabot-automerge
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+jobs:
+  automerge:
+    uses: bufbuild/base-workflows/.github/workflows/dependabot-automerge.yaml@main
+    with:
+      github-auto-merge: true
+```
+
+For repositories **without** required status checks:
+
+```yaml
+name: dependabot-automerge
+on:
+  pull_request:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: ["dependabot/**"]
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+jobs:
+  automerge:
+    uses: bufbuild/base-workflows/.github/workflows/dependabot-automerge.yaml@main
+    with:
+      github-auto-merge: false
+```
+
+`workflows` is a list of your CI workflows, matched by their `name:` —
+the checks that must complete before it's considered safe to auto-merge.
+A name that matches nothing is a silently dead trigger; the cron backstop
+still works.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    PR[Dependabot PR opens or updates] --> mark["mark: classify with fetch-metadata"]
+    mark -->|patch / minor| label["label: automerge: eligible"]
+    mark -->|major| human[no label - waits for a human]
+    label -->|github-auto-merge: true| arm["arm native auto-merge - GitHub merges when required checks pass"]
+    label -->|github-auto-merge: false| done[done - exit in seconds]
+    ci["CI completes on a dependabot/** branch"] --> sweep
+    cron[cron backstop / manual dispatch] --> sweep
+    sweep["sweep: one look per labeled PR"] -->|green, or no CI at all| merge[squash-merge]
+    sweep -->|pending or failing| retry[skip - retry next wake]
+```
+
+## The two jobs
+
+This workflow contains two jobs.
+
+**mark** (`pull_request`) — runs only when Dependabot is both the PR's
+author and its most recent pusher. Classifies the update with
+[dependabot/fetch-metadata](https://github.com/dependabot/fetch-metadata)
+— precise semver level, including every member of a grouped update.
+Patch/minor gets the `automerge: eligible` label; anything else has the
+label removed and any previously armed auto-merge disarmed, so a grouped
+PR that gains a major member on update loses its mark and will not merge.
+With `github-auto-merge: true` it also approves and arms GitHub native
+auto-merge (`gh pr merge --auto --squash`); GitHub merges once required
+status checks pass. With `github-auto-merge: false` it stops at the
+label.
+
+**sweep** (`workflow_run` / `schedule` / `workflow_dispatch`) — lists
+open Dependabot-authored PRs carrying the label and takes one look at
+each: any failing or pending check → skip, retried on the next wake; all
+green → approve and squash-merge; no CI checks at all → merge as-is (a
+repository without CI already accepts every change unverified). It never
+classifies anything and never waits. Wakes when the repository's named CI
+workflow completes successfully on a `dependabot/**` branch — the
+`branches:` filter means other CI completions never even create a run —
+plus a cron backstop and manual dispatch. Concurrent wakes coalesce into
+one running sweep and one queued.
+
+## Sweep decision, per PR
+
+| PR state at sweep time | Action |
+|---|---|
+| All checks green | Approve + squash-merge |
+| No CI checks at all | Approve + squash-merge |
+| Any check pending | Skip — retry next wake |
+| Any check failed/cancelled | Skip — retry next wake |
+| No label | Never considered |
+
+## Choosing a value for `github-auto-merge`
+
+| Repository | `github-auto-merge` | Merge timing |
+|---|---|---|
+| Required status checks configured | `true` | Same-hour: GitHub merges when checks pass |
+| No required checks | `false` | At the next sweep wake after CI passes — usually minutes, via `workflow_run` |
+| No CI at all | `false` | Next cron tick; merges ungated, by explicit choice |
+
+The two settings gate differently: `false` (the sweep) waits on **all**
+of a PR's checks; `true` waits only on **required** ones.
+
+Some rulesets don't count bot approvals toward required reviews — if a
+review-requiring repository stalls at "Review required" despite the
+workflow's approval, that's why.
+
+> [!WARNING]
+> `github-auto-merge: true` on a repository without required checks
+> merges eligible PRs immediately, without waiting for any checks. Only
+> set it to `true` once the branch-protection setup ("required status
+> checks" + "Allow auto-merge") is done.

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,0 +1,105 @@
+# Auto-merge for Dependabot PRs. Patch/minor updates are labeled
+# "automerge: eligible" as they arrive, then merged; majors never qualify
+# and wait for a human. Adding the label by hand arms a PR for the next
+# sweep; removing it vetoes one.
+#
+# If github-auto-merge is true, GitHub native auto-merge is armed on
+# eligible PRs; else, a sweep job merges PRs periodically after checks are green.
+#
+# WARNING: only use github-auto-merge on repos with required status checks.
+# Setting github-auto-merge on a repo without required checks will result in
+# PRs merging immediately without waiting for CI (probably not what you want).
+name: dependabot-automerge
+on:
+  workflow_call:
+    inputs:
+      github-auto-merge:
+        type: boolean
+        required: true
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+jobs:
+  # Classifies each Dependabot PR with fetch-metadata and records the
+  # verdict as the label. Re-runs on every Dependabot push, so a PR that
+  # stops qualifying (e.g. a grouped update gains a major member) loses
+  # its label and any previously armed auto-merge.
+  mark:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot Metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+      - name: Label Eligible PR
+        id: label
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create "automerge: eligible" --repo "${REPO}" --force
+          gh pr edit "${PR_URL}" --add-label "automerge: eligible"
+      - name: Remove Stale Label
+        if: >-
+          steps.metadata.outputs.update-type != 'version-update:semver-patch' &&
+          steps.metadata.outputs.update-type != 'version-update:semver-minor'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr edit "${PR_URL}" --remove-label "automerge: eligible" || true
+          gh pr merge --disable-auto "${PR_URL}" || true
+      - name: Enable Auto-Merge
+        if: inputs.github-auto-merge && steps.label.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review --approve "${PR_URL}"
+          gh pr merge --auto --squash "${PR_URL}"
+  # Merges open labeled Dependabot PRs whose checks are green, one look
+  # per PR, no waiting. The triggers that wake it (workflow_run, schedule,
+  # workflow_dispatch) live in the caller stub.
+  sweep:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' &&
+       github.event.workflow_run.conclusion == 'success' &&
+       startsWith(github.event.workflow_run.head_branch, 'dependabot/'))
+    concurrency:
+      group: dependabot-automerge-sweep
+      cancel-in-progress: false
+    steps:
+      - name: Merge Labeled Dependabot PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr list --repo "${REPO}" --author 'app/dependabot' \
+            --label "automerge: eligible" --state open --limit 100 --json url \
+            --jq '.[].url' |
+          while read -r url; do
+            # `gh pr checks` errors when a PR has no checks; that counts
+            # as zero blockers and merges — a repository without CI
+            # already accepts every change unverified.
+            blocked=$(gh pr checks "${url}" --json bucket \
+              --jq '[.[] | select(.bucket == "fail" or .bucket == "cancel" or .bucket == "pending")] | length' \
+              2>/dev/null) || true
+            if [ "${blocked:-0}" -eq 0 ]; then
+              gh pr review --approve "${url}" &&
+                gh pr merge --squash "${url}" ||
+                echo "failed to merge ${url}" >&2
+            else
+              echo "skipping ${url}: ${blocked} check(s) not green"
+            fi
+          done


### PR DESCRIPTION
Marks eligible patch/minor Dependabot PRs with a label and merges them via GitHub native auto-merge or a scheduled sweep. Majors wait for a human; the label is the manual override.